### PR TITLE
Fix: Update linuxinstall.sh for Kali Linux compatibility

### DIFF
--- a/linuxinstall.sh
+++ b/linuxinstall.sh
@@ -10,17 +10,19 @@ sleep 3
 echo -e "$b"">""$w"" installing package: ""$g""libxml2""$w"
 sudo apt install libxml2 -y
 echo -e "$b"">""$w"" installing pacakge: ""$g""libxslt""$w"
-sudo apt install libxslt -y
+sudo apt install libxslt1.1 -y
 echo -e "$b"">""$w"" installing pacakge: ""$g""python3""$w"
-sudo apt install python -y
+sudo apt install python3 python-is-python3 -y
+echo -e "$b"">""$w"" installing package: ""$g""python3-pip""$w"
+sudo apt install python3-pip -y
 echo -e "$b"">""$w"" installing modules: ""$g""lxml""$w"
-pip3 install wheel lxml
+sudo apt install python3-lxml python3-wheel -y
 echo -e "$b"">""$w"" installing modules: ""$g""requests""$w"
-pip3 install requests
+sudo apt install python3-requests -y
 echo -e "$b"">""$w"" installing modules: ""$g""BeautifulSoup""$w"
-pip install beautifulsoup4
+sudo apt install python3-bs4 -y
 echo -e "$b"">""$w"" installing modules: ""$g""tabuate""$w"
-pip3 install tabulate
+sudo apt install python3-tabulate -y
 echo -e "$b"">""$w"" successfully installing dependencies"
-wget -q https://raw.githubusercontent.com/C0MPL3XDEV/E4GL3OS1NT/main/E4GL30S1NT.py -O "$PREFIX"/bin/E4GL30S1NT && chmod +x "$PREFIX"/bin/E4GL30S1NT
+sudo wget -q https://raw.githubusercontent.com/C0MPL3XDEV/E4GL3OS1NT/main/E4GL30S1NT.py -O /usr/local/bin/E4GL30S1NT && sudo chmod +x /usr/local/bin/E4GL30S1NT
 echo -e "$b"">""$w"" use command ""$g""E4GL30S1NT""$w"" for start the console"


### PR DESCRIPTION
The linuxinstall.sh script has been updated to address installation issues on Kali Linux.

Changes include:
- Corrected apt package names:
    - 'libxslt' to 'libxslt1.1'
    - 'python' to 'python3' and 'python-is-python3'
- Switched Python module installation from pip to apt:
    - lxml, requests, beautifulsoup4, tabulate are now installed using their python3-* equivalents (e.g., python3-lxml).
    - Added installation of 'python3-pip' for general pip availability.
    - Added installation of 'python3-wheel'.
- Standardized E4GL30S1NT script installation:
    - The script is now downloaded to /usr/local/bin/E4GL30S1NT.
    - sudo is used for both wget (to write to /usr/local/bin) and chmod +x.

These changes ensure that the installation process respects Kali Linux's packaging policies (PEP 668) and correctly installs all dependencies and the main tool.